### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build_and_release_windows.yml
+++ b/.github/workflows/build_and_release_windows.yml
@@ -1,5 +1,8 @@
 name: Build, Sign & Release CLPE
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main ]
@@ -45,6 +48,8 @@ jobs:
   build-windows-installer:
     runs-on: windows-latest
     needs: build-linux
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python


### PR DESCRIPTION
Potential fix for [https://github.com/keyurp7/cloak-iam/security/code-scanning/2](https://github.com/keyurp7/cloak-iam/security/code-scanning/2)

To fix the problem, you should add a `permissions` block to the workflow file, specifying the minimum required permissions for the jobs. Since the workflow uploads release artifacts and interacts with GitHub releases, it needs `contents: read` for most steps, and `contents: write` for the release upload step. However, the minimal starting point is to set `contents: read` at the workflow level, and then override with `contents: write` for the job or step that uploads to the release (using `softprops/action-gh-release`). The best way to do this is to add a `permissions` block at the top level of the workflow (after `name:` and before `on:`), and, if needed, override it for the job or step that requires additional permissions.

You only need to edit the `.github/workflows/build_and_release_windows.yml` file, adding the `permissions` block at the root level, and optionally at the job level for `build-windows-installer` if you want to be more granular.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
